### PR TITLE
Use correct abort key for API access error and add reason to error message

### DIFF
--- a/custom_components/google_fit/translations/en.json
+++ b/custom_components/google_fit/translations/en.json
@@ -6,7 +6,7 @@
     "abort": {
       "already_configured": "Account is already configured",
       "already_in_progress": "Configuration flow is already in progress",
-      "api_disabled": "You must enable the Google Fit API in the Google Cloud Console",
+      "access_error": "Fit API Access error:\n{reason}\nAborting setup.",
       "cannot_connect": "Failed to connect",
       "code_expired": "Authentication code expired or credential setup is invalid, please try again.",
       "invalid_access_token": "Invalid access token",


### PR DESCRIPTION
The abort key didn't line up to the one configured in config_flow.py (line 105).

On top of this I also added the reason to get a more detailed error message. Example:
![image](https://github.com/YorkshireIoT/ha-google-fit/assets/55233103/86e158fd-d5be-463b-bb2f-d6e6e7340543)
