### PR TITLE
Remove use_zero configuration and use zero as base/default value for cumulative sensors

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,8 +114,52 @@ The following options can be tweaked after setting up the integration:
 Option | Description | Default
 ------------ | ------------- | -------------
 Update interval | Minutes between REST API queries. Can be increased if you're exceeding API quota | 5 (minutes) |
-Unknown value | When there is no data available in your Google Fit account within the time period, set the sensor value to 0 or unknown | Set to 0 |
 
+## Unknown Sensor Behaviour
+
+All sensors in this integration can be grouped into two categories; cumulative or individual.
+This is due to how data is reported in your Google Fit account. Every piece of data is only associated
+with a time period and has no underlying logic for running totals.
+
+For example, steps are reported like this in your account:
+
+* 1st January 2023 9:32:01 - 495
+* 2nd January 2023 11:54:03 - 34
+* 2nd January 2023 13:02:40 - 1005
+* 2nd January 2023 17:16:27 - 842
+
+There is then some built-in logic in this integration to work out what
+sensor we're dealing with, and to either sum up these values over a
+logical time period, or to just take the latest known value, when the
+sensor is something like height.
+
+> If you're interested in all the underlying logic, it's contained in
+> [api.py](/custom_components/google_fit/api.py).
+
+The behaviour of this integration when there is *no* data available in your account differs
+depending on the sensor category.
+
+*Cumulative* sensors will use 0 as their base value and this will be their value in Home Assistant
+if their is no data in your Google Fit account for that sensor.
+
+*Individual* sensors will only report a value if they can find some data in your Google Fit account.
+Otherwise, they will show `Unknown`.
+
+### Unavailable
+
+Besides `Unknown`, there is an additional Home Assistant sensor state; `Unavailable`.
+
+This state has nothing to do with if there is or isn't data in your account. It indicates some error
+in the fetching of the data. Your internet has stopped working, or maybe the Google servers are
+down. In some cases, it may also indicate there is a bug with this integration. If that is the case,
+please report it as a bug.
+
+There are no plans to ignore these data fetching issues and retain the last known sensor
+value. The reasoning for this is:
+
+* This is the correct representation of the sensors state, and
+* It indicates to the user that there is some underlying issue with the integration itself
+and this should not be hidden.s
 
 ## Adding Multiple Accounts
 

--- a/custom_components/google_fit/api.py
+++ b/custom_components/google_fit/api.py
@@ -164,7 +164,7 @@ class GoogleFitParse:
     ) -> float | None:
         """Get the most recent floating point value.
 
-        N.B. If no data exists in the account return None.
+        If no data exists in the account return None.
         """
         value = None
         data_points = response.get("insertedDataPoint")

--- a/custom_components/google_fit/config_flow.py
+++ b/custom_components/google_fit/config_flow.py
@@ -20,9 +20,7 @@ from .api_types import FitService
 from .const import (
     DEFAULT_ACCESS,
     DOMAIN,
-    CONF_NO_DATA_USE_ZERO,
     DEFAULT_SCAN_INTERVAL,
-    DEFAULT_NO_DATA_USE_ZERO,
 )
 
 
@@ -144,12 +142,6 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
                             CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL
                         ),
                     ): config_validation.positive_int,
-                    vol.Required(
-                        CONF_NO_DATA_USE_ZERO,
-                        default=self.config_entry.options.get(
-                            CONF_NO_DATA_USE_ZERO, DEFAULT_NO_DATA_USE_ZERO
-                        ),
-                    ): config_validation.boolean,
                 }
             ),
         )

--- a/custom_components/google_fit/const.py
+++ b/custom_components/google_fit/const.py
@@ -29,12 +29,8 @@ NAME: Final = "Google Fit"
 DOMAIN: Final = "google_fit"
 MANUFACTURER: Final = "Google, Inc."
 
-# Configuration schema
-CONF_NO_DATA_USE_ZERO: Final = "use_zero"
-
 # Default Configuration Values
 DEFAULT_SCAN_INTERVAL = 5
-DEFAULT_NO_DATA_USE_ZERO = True
 
 # Useful constants
 NANOSECONDS_SECONDS_CONVERSION: Final = 1000000000

--- a/custom_components/google_fit/sensor.py
+++ b/custom_components/google_fit/sensor.py
@@ -32,6 +32,7 @@ class GoogleFitBlueprintSensor(GoogleFitEntity, SensorEntity):
     """Google Fit Template Sensor class."""
 
     entity_description: GoogleFitSensorDescription
+    coordinator: Coordinator
 
     def __init__(
         self,
@@ -41,6 +42,7 @@ class GoogleFitBlueprintSensor(GoogleFitEntity, SensorEntity):
         """Initialise the sensor class."""
         super().__init__(coordinator)
         self.entity_description = entity_description
+        self.coordinator = coordinator
         # Follow method in core Google Mail component and use oauth session to create unique ID
         if coordinator.oauth_session:
             self._attr_unique_id = (
@@ -62,10 +64,6 @@ class GoogleFitBlueprintSensor(GoogleFitEntity, SensorEntity):
             value = self.coordinator.current_data.get(self.entity_description.data_key)
             if value is not None:
                 self._attr_native_value = value
-                self.async_write_ha_state()
-            # If value is None but config says to use zero value to prevent unknown
-            elif self.coordinator.use_zero:
-                self._attr_native_value = 0
                 self.async_write_ha_state()
 
     @callback

--- a/custom_components/google_fit/translations/en.json
+++ b/custom_components/google_fit/translations/en.json
@@ -37,8 +37,7 @@
         "title": "Google Fit Settings",
         "description": "For help with settings, see [Configuration Options](https://github.com/YorkshireIoT/ha-google-fit#configuration)",
         "data": {
-          "scan_interval": "Minutes between REST API queries.",
-          "use_zero": "When there is no data available on the account for a sensor set to zero. If unchecked, set to unknown."
+          "scan_interval": "Minutes between REST API queries."
         }
       }
     }

--- a/custom_components/google_fit/translations/sk.json
+++ b/custom_components/google_fit/translations/sk.json
@@ -37,8 +37,7 @@
         "title": "Google Fit nastavenia",
         "description": "Pomoc s nastaveniami nájdete v časti [Configuration Options](https://github.com/YorkshireIoT/ha-google-fit#configuration)",
         "data": {
-          "scan_interval": "Minúty medzi dopytmi REST API.",
-          "use_zero": "Keď na účte nie sú k dispozícii žiadne údaje pre snímač nastavený na nulu. Ak nie je začiarknuté, nastavte na neznáme."
+          "scan_interval": "Minúty medzi dopytmi REST API."
         }
       }
     }


### PR DESCRIPTION
* Behaviour for sensors that are cumulative, e.g. steps, will be to show 0 if no data exists in the account
* Behaviour for sensors that aren't cumulative, e.g. height, will be to return "Unknown" if no data exists the account
* Update docs to explain integration behaviour