### PR TITLE
109 multiple accounts shown together in device view

### DIFF
--- a/custom_components/google_fit/__init__.py
+++ b/custom_components/google_fit/__init__.py
@@ -12,6 +12,7 @@ from homeassistant.helpers.config_entry_oauth2_flow import (
     OAuth2Session,
     async_get_config_entry_implementation,
 )
+from homeassistant.helpers.device_registry import DeviceEntry
 
 from .coordinator import Coordinator
 
@@ -79,3 +80,10 @@ async def async_reload_entry(hass: HomeAssistant, entry: ConfigEntry) -> None:
     """Reload config entry."""
     await async_unload_entry(hass, entry)
     await async_setup_entry(hass, entry)
+
+
+async def async_remove_config_entry_device(
+    hass: HomeAssistant, config_entry: ConfigEntry, device_entry: DeviceEntry
+) -> bool:
+    """Remove Google Fit config entry."""
+    return True

--- a/custom_components/google_fit/entity.py
+++ b/custom_components/google_fit/entity.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
+from homeassistant.exceptions import InvalidStateError
 
 from .const import DOMAIN, NAME, MANUFACTURER
 from .coordinator import Coordinator
@@ -14,8 +15,16 @@ class GoogleFitEntity(CoordinatorEntity):
     def __init__(self, coordinator: Coordinator) -> None:
         """Initialise."""
         super().__init__(coordinator)
-        self._attr_device_info = DeviceInfo(
-            identifiers={(DOMAIN, self.unique_id)},  # type: ignore
-            name=NAME,
-            manufacturer=MANUFACTURER,
-        )
+        if coordinator.config_entry and coordinator.config_entry.unique_id:
+            email = coordinator.config_entry.unique_id
+            self._attr_device_info = DeviceInfo(
+                identifiers={(DOMAIN, email)},
+                name=f"{NAME} - {email}",
+                manufacturer=MANUFACTURER,
+                model="fitness",
+                sw_version="v1",
+            )
+        else:
+            raise InvalidStateError(
+                "Unexpected exception. Trying to initialise entity but config entry is None."
+            )


### PR DESCRIPTION
Adds unique device info to a Google Fit device so different accounts are properly distinguish in Home Assistant.

⚠️ This is a breaking change! It will create a new device due to the new device information. Any references will have to be updated.

This pull request also adds the ability to remove an existing device configuration, as the old device will be orphaned and should be removed.